### PR TITLE
replace the default behavior for SIGTERM and SIGINT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
- 
+
+## [0.3.0] - 2025-07-03
+
+### Added
+
+- `initProcessHandlers` additionally hooks onto signals `SIGTERM` and `SIGINT` by 
+default. They simply dispatch to `gracefulShutdown` to create a more coherent experience.
+
 ## [0.2.0] - 2025-07-03
 
 ### Changed

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -233,11 +233,13 @@ describe("index", function () {
 
         // It should register on all three node events.
         const onCalls = processOn.getCalls();
-        expect(onCalls).to.have.length(3);
+        expect(onCalls).to.have.length(5);
         // The order doesn't matter, but that's how it is now.
         expect(onCalls[0].firstArg).to.equal("uncaughtException");
         expect(onCalls[1].firstArg).to.equal("unhandledRejection");
         expect(onCalls[2].firstArg).to.equal("beforeExit");
+        expect(onCalls[3].firstArg).to.equal("SIGTERM");
+        expect(onCalls[4].firstArg).to.equal("SIGINT");
         // It also registers on worker events, but we'll test that later.
       });
     });


### PR DESCRIPTION
- Instead of letting Node.js do its thing, direct to the graceful
shutdown logic. In other words, hook onto SIGTERM and SIGINT by
default and simply dispatch to graceful shutdown.
